### PR TITLE
Add workflow and script for automatic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  packages: write
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build project
+      run: npm run build
+
+    - name: Zip dist folder
+      run: zip -r adonys.me-website-build-${{ github.ref_name }}.zip dist
+
+    - name: Create and Upload Release
+      uses: softprops/action-gh-release@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        files: ./adonys.me-website-build-${{ github.ref_name }}.zip
+        tag_name: ${{ github.ref }}
+        name: Release ${{ github.ref_name }}

--- a/release.sh
+++ b/release.sh
@@ -25,4 +25,16 @@ echo "The package.json files has been updated and committed"
 git tag -a "v$NEW_VERSION" -m "Release $NEW_VERSION"
 echo "A new tag v$NEW_VERSION has been created"
 
-echo "The release is ready to be pushed to the remote repository"
+# Ask the user if he wants to push the changes to the remote repository currently origin
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+echo "Do you want to push the changes to the remote repository (origin) for branch $current_branch? (y/n)"
+read answer
+
+if [ "$answer" != "${answer#[Yy]}" ] ;then
+  git push sandbox $current_branch
+  git push sandbox "v$NEW_VERSION"
+else
+  echo "You chose not to push the changes to the remote repository"
+  exit 0
+fi
+

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# This script create a new release for the project
+# It updates the version in package.json, commits the change
+# creates a new tag and pushes the changes to the remote repository
+# Usage: ./release.sh <new_version>
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <new_version>"
+  exit 1
+fi
+
+NEW_VERSION=$1
+
+jq --arg ver "$NEW_VERSION" '.version = $ver' package.json > tmp.$$.json && mv tmp.$$.json package.json
+
+if [ $? -ne 0 ]; then
+  echo "Error updating the version in package.json"
+  exit 1
+fi
+
+git add package.json
+git commit -m "Update version to $NEW_VERSION"
+echo "The package.json files has been updated and committed"
+
+git tag -a "v$NEW_VERSION" -m "Release $NEW_VERSION"
+echo "A new tag v$NEW_VERSION has been created"
+
+echo "The release is ready to be pushed to the remote repository"


### PR DESCRIPTION
This PR adds a `release.sh` script to create a new release for the project.

It updates the version in package.json, commits the changes and creates a new tag and pushes the changes to the remote repository.

**Usage:** `./release.sh <new_version>`

Also, adds the release workflow that create the website build, compress it and the upload to the [GitHub Release](https://github.com/adonyssantos/adonys-dot-me-website/releases) project tab.